### PR TITLE
Allow callers to not set an`APIKey`

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,14 @@ module.exports = function setup(name, gitSha, options, process = 'http') {
   if (options == 'mock') {
     config.impl = 'mock';
   } else {
-    config.writeKey = options.APIKey;
+    // config.WriteKey must be set to a non-empty value, but when we use Refinery to aggregate all of our events
+    // and send them using its own WriteKey, we don't need to specify app-specific WriteKeys.
+    // The `beeline-go` package sets a default WriteKey (which is invalid as far as Honeycomb goes)
+    // to allow the tracing library to be initialized.
+    // https://github.com/honeycombio/beeline-go/blob/56c4f55d6efec3d417ba32748718fefd2e362a0f/beeline.go#L22
+    const defaultWriteKey = 'apikey-placeholder';
+
+    config.writeKey = options.APIKey || defaultWriteKey;
     config.dataset = options.TracingDataset;
     config.sampleRate = options.DesiredSampleRate;
     /** @param {{ data: Record<string, unknown>}} ev */


### PR DESCRIPTION
Traces from other apps were [appearing](https://ui.honeycomb.io/geckoboard/environments/development/datasets/concierge/result/gEiG8DBbmXh) in Concierge's dataset in the Dev Environment. 

This behaviour was quite similar to the way that `turnstile` was also 'stealing' other apps' traces and [writing them to the wrong dataset](https://geckoboard.slack.com/archives/C023NLFPK5H/p1727090320775619). 

The "fix" for Turnstile was to remove its Honeycomb APIKey (`WriteKey`), which meant that Refinery could work as expected (i.e. disregard apps' individual keys and write using its own WriteKey). 

When I tried this for Concierge, it turned out that the `beeline-nodejs` library [couldn't be initialized](https://github.com/honeycombio/beeline-nodejs/blob/c836ab971c88a63bbb858e18d70d4dac8a7fbb3d/lib/api/libhoney.js#L89-L91) with an empty `WriteKey` being passed to it. 

`beeline-go` [gets around this](https://github.com/honeycombio/beeline-go/blob/56c4f55d6efec3d417ba32748718fefd2e362a0f/beeline.go#L111-L114) by quietly setting a default (invalid, but non-empty) `WriteKey` value when the package is instantiated without one being passed to it. 

Since `beeline-nodejs` is considered a "legacy" integration for Honeycomb (they prefer you to use OpenTelemetry these days), submitting a PR there to bring it up to par with `beeline-go` seemed a bit much, so instead I'm proposing that we do this inside our own wrapper for `beeline-nodejs`.