### PR TITLE
add memory and uptime metrics to every span

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -58,6 +58,7 @@ it('configures honeycomb for sending events', async () => {
 
   const trace = beeline.startTrace({ field: 'value' }, 'trace1', 'parent1');
   if (trace) beeline.finishTrace(trace);
+  await beeline.flush();
 
   const call = await callP;
 
@@ -73,6 +74,8 @@ it('configures honeycomb for sending events', async () => {
         'service.process': 'http',
         app_sha: 'beefdad',
         global: 'fields',
+        'process.uptime_s': expect.any(Number),
+        'process.memory_rss': expect.any(Number),
       },
     },
   ]);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint-ci": "bash -o pipefail -c 'eslint --format junit --ext .js,.ts ./instrumentation | tee test-reports/eslint.xml'",
     "typecheck": "tsc",
     "test": "jest",
-    "test-ci": "JEST_JUNIT_OUTPUT_FILE=test-reports/jest.xml jest --maxWorkers 4 --coverage --testResultsProcessor jest-junit"
+    "test-ci": "jest --maxWorkers 2 --coverage --testResultsProcessor jest-junit"
   },
   "peerDependencies": {
     "honeycomb-beeline": "^3.3.0"


### PR DESCRIPTION
To bring us closer to parity with the Go telemetry, and help keep an eye on memory leaks, we'll start recording heap size and total memory usage