### PR TITLE
include process.pid field

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = function setup(name, gitSha, options, processType = 'http') {
       ev.data.app_sha = gitSha;
       ev.data['service.process'] = processType;
       ev.data['process.uptime_s'] = Math.round(process.uptime());
+      ev.data['process.pid'] = process.pid;
 
       Object.entries(globalMetadata).forEach(([k, v]) => {
         ev.data[k] = v;


### PR DESCRIPTION
On some machines we run multiple instances of the same process, and there's no other way to tell them apart, except by their process IDs - so it would help if we actually recorded them