### PR TITLE
Version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-support",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "honeycomb-support",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Helpful stuff for adding honeycomb to a nodejs app",
   "main": "index.js",
   "repository": "git@github.com:geckoboard/js-honeycomb-support.git",


### PR DESCRIPTION
I didn't think we needed this when installing from GitHub, but I can't get `nodeutils` to pull the new version. By bumping it I can at least see if it's worked.